### PR TITLE
Riot Account API 작성

### DIFF
--- a/src/main/kotlin/com/lol/analyzer/aram/account/application/AccountService.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/account/application/AccountService.kt
@@ -5,6 +5,7 @@ import com.lol.analyzer.aram.account.dto.AccountDomain
 import com.lol.analyzer.aram.account.dto.AccountResponse
 import com.lol.analyzer.aram.account.domain.Account
 import com.lol.analyzer.aram.account.domain.AccountRepository
+import com.lol.analyzer.aram.account.exception.NotFoundException
 import com.lol.analyzer.aram.riot.domain.RiotApi
 import org.springframework.stereotype.Service
 
@@ -14,7 +15,7 @@ class AccountService(
     private val riotApi: RiotApi
 ) {
     fun getAccountByUuid(uuid: String): AccountResponse {
-        val account = this.accountRepository.findByUuid(uuid) ?: throw IllegalArgumentException(
+        val account = this.accountRepository.findByUuid(uuid) ?: throw NotFoundException(
                 "No account with that uuid."
         )
 

--- a/src/main/kotlin/com/lol/analyzer/aram/account/application/AccountService.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/account/application/AccountService.kt
@@ -22,16 +22,17 @@ class AccountService(
         return AccountResponse.from(account)
     }
 
-    fun create(createRequest: AccountCreateRequest): AccountResponse {
-        val accountDomain = AccountDomain.from(createRequest)
-
+    fun getAccountByRiotInfo(
+        gameName: String,
+        tagLine: String
+    ): AccountResponse {
         var account = this.accountRepository.findByGameNameAndTagLine(
-            accountDomain.gameName,
-            accountDomain.tagLine
+            gameName,
+            tagLine
         )
 
         if (account == null) {
-            val accountResponse = riotApi.getAccountByRiotId(createRequest.gameName, createRequest.tagLine)
+            val accountResponse = riotApi.getAccountByRiotId(gameName, tagLine)
             account = this.accountRepository.save(
                 Account(
                     puuid = accountResponse.puuid,

--- a/src/main/kotlin/com/lol/analyzer/aram/account/application/AccountService.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/account/application/AccountService.kt
@@ -13,9 +13,9 @@ class AccountService(
     private val accountRepository: AccountRepository,
     private val riotApi: RiotApi
 ) {
-    fun getAccountByPuuid(puuid: String): AccountResponse {
-        val account = this.accountRepository.findByPuuid(puuid) ?: throw IllegalArgumentException(
-                "No account with that puuid."
+    fun getAccountByUuid(uuid: String): AccountResponse {
+        val account = this.accountRepository.findByUuid(uuid) ?: throw IllegalArgumentException(
+                "No account with that uuid."
         )
 
         return AccountResponse.from(account)

--- a/src/main/kotlin/com/lol/analyzer/aram/account/domain/Account.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/account/domain/Account.kt
@@ -5,19 +5,27 @@ import jakarta.persistence.*
 import org.hibernate.annotations.Comment
 import java.util.UUID
 
-@Entity(name = "accounts")
+@Entity
+@Table(
+        name = "accounts",
+        indexes = [
+                Index(name = "idx_uuid", columnList = "uuid", unique = true),
+                Index(name = "idx_game_name_and_tag_line", columnList = "gameName, tagLine", unique = true)
+        ]
+)
 class Account(
-        @Column
+        @Column(unique = true)
         @Comment("Riot 계정의 puuid")
         var puuid: String,
 
-        @Column(name = "game_name")
+        // https://support-leagueoflegends.riotgames.com/hc/en-us/articles/360041788533-Riot-ID-FAQ
+        @Column(name = "game_name", length = 20)
         var gameName: String,
 
-        @Column(name = "tag_line")
+        @Column(name = "tag_line", length = 10)
         var tagLine: String,
 
-        @Column
+        @Column(unique = true)
         @Comment("Aram 서비스 내에서의 uuid")
         var uuid: String? = null,
 ):BaseEntity() {

--- a/src/main/kotlin/com/lol/analyzer/aram/account/domain/AccountRepository.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/account/domain/AccountRepository.kt
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 interface AccountRepository: JpaRepository<Account, Long> {
-    fun findByPuuid(puuid: String): Account?
+    fun findByUuid(uuid: String): Account?
     fun findByGameNameAndTagLine(gameName: String, tagLine: String): Account?
 }

--- a/src/main/kotlin/com/lol/analyzer/aram/account/dto/AccountResponse.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/account/dto/AccountResponse.kt
@@ -3,12 +3,13 @@ package com.lol.analyzer.aram.account.dto
 import com.lol.analyzer.aram.account.domain.Account
 
 data class AccountResponse(
+        val uuid: String?,
         val gameName: String,
         val tagLine: String,
 ) {
     companion object {
         fun from(account: Account): AccountResponse {
-            return AccountResponse(account.gameName, account.tagLine)
+            return AccountResponse(account.uuid, account.gameName, account.tagLine)
         }
     }
 }

--- a/src/main/kotlin/com/lol/analyzer/aram/account/exception/AccountException.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/account/exception/AccountException.kt
@@ -1,0 +1,9 @@
+package com.lol.analyzer.aram.account.exception
+
+import com.lol.analyzer.aram.common.enums.ErrorCode
+
+open class AccountException(
+    override val message: String,
+    open var errorCode: ErrorCode = ErrorCode.UNDEFINED,
+): Exception(message) {
+}

--- a/src/main/kotlin/com/lol/analyzer/aram/account/exception/ExceptionHandler.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/account/exception/ExceptionHandler.kt
@@ -2,6 +2,7 @@ package com.lol.analyzer.aram.account.exception
 
 import com.lol.analyzer.aram.account.dto.ExceptionResponse
 import com.lol.analyzer.aram.common.enums.ErrorCode
+import org.springframework.http.HttpStatusCode
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -12,5 +13,11 @@ class ExceptionHandler {
     @ExceptionHandler(WebClientResponseException::class)
     fun webClientResponseException(e: WebClientResponseException): ResponseEntity<ExceptionResponse> {
         return ResponseEntity(ExceptionResponse(e.statusCode.value(), ErrorCode.RIOT_RESPONSE_ERROR, e.message), e.statusCode)
+    }
+
+    @ExceptionHandler(AccountException::class)
+    fun accountException(e: AccountException): ResponseEntity<ExceptionResponse> {
+        val statusCode = HttpStatusCode.valueOf(400)
+        return ResponseEntity(ExceptionResponse(statusCode.value(), e.errorCode, e.message), statusCode)
     }
 }

--- a/src/main/kotlin/com/lol/analyzer/aram/account/exception/NotFoundException.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/account/exception/NotFoundException.kt
@@ -1,0 +1,10 @@
+package com.lol.analyzer.aram.account.exception
+
+import com.lol.analyzer.aram.common.enums.ErrorCode
+
+
+class NotFoundException(
+    override val message: String,
+    override var errorCode: ErrorCode = ErrorCode.RECORD_NOT_FOUND
+): AccountException(message) {
+}

--- a/src/main/kotlin/com/lol/analyzer/aram/account/presentation/AccountController.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/account/presentation/AccountController.kt
@@ -18,10 +18,10 @@ import org.springframework.web.bind.annotation.RestController
 class AccountController(
         private val accountService: AccountService
 ) {
-    @GetMapping("/by-puuid/{puuid}")
-    @Operation(description = "PUUID 로 Account 조회")
-    fun getAccount(@PathVariable("puuid") puuid: String): AccountResponse {
-        return this.accountService.getAccountByPuuid(puuid)
+    @GetMapping("/by-uuid/{uuid}")
+    @Operation(description = "UUID 로 Account 조회")
+    fun getAccount(@PathVariable("uuid") uuid: String): AccountResponse {
+        return this.accountService.getAccountByUuid(uuid)
     }
 
     @PostMapping()

--- a/src/main/kotlin/com/lol/analyzer/aram/account/presentation/AccountController.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/account/presentation/AccountController.kt
@@ -20,14 +20,17 @@ class AccountController(
 ) {
     @GetMapping("/by-uuid/{uuid}")
     @Operation(description = "UUID 로 Account 조회")
-    fun getAccount(@PathVariable("uuid") uuid: String): AccountResponse {
+    fun getAccountByUuid(@PathVariable("uuid") uuid: String): AccountResponse {
         return this.accountService.getAccountByUuid(uuid)
     }
 
-    @PostMapping()
-    @Operation(description = "Account 생성")
-    fun createAccount(@RequestBody accountCreateRequest: AccountCreateRequest): AccountResponse {
-        return this.accountService.create(accountCreateRequest)
+    @GetMapping("/by-riot-info/{gameName}/{tagLine}")
+    @Operation(description = "Game Name & Tag Line 으로 Account 조회")
+    fun getAccountByRiotInfo(
+        @PathVariable("gameName") gameName: String,
+        @PathVariable("tagLine") tagLine: String
+    ): AccountResponse {
+        return this.accountService.getAccountByRiotInfo(gameName, tagLine)
     }
 
 }

--- a/src/main/kotlin/com/lol/analyzer/aram/common/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/common/config/SwaggerConfig.kt
@@ -30,7 +30,7 @@ class SwaggerConfig {
 
     private fun apiInfo(): Info {
         return Info()
-                .title("API Test")
+                .title("ARAM API")
                 .description("ARAM LoL Analyzer API")
                 .version("1.0.0")
     }

--- a/src/main/kotlin/com/lol/analyzer/aram/common/enums/ErrorCode.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/common/enums/ErrorCode.kt
@@ -1,6 +1,10 @@
 package com.lol.analyzer.aram.common.enums
 
 enum class ErrorCode(val code: String) {
+    // common
+    UNDEFINED("0000"),
+    RECORD_NOT_FOUND("0404"),
+
     // riot
     RIOT_RESPONSE_ERROR("9000")
 }


### PR DESCRIPTION
## 작업 내용
- gameName & tagLine 으로 account 조회하는 API 추가
>- 기존 POST 메소드로 정의했으나 GET 메소드로 변경
>- API route 변경