### PR TITLE
Riot API 를 서비스별로 분리

### DIFF
--- a/src/main/kotlin/com/lol/analyzer/aram/common/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/common/config/SwaggerConfig.kt
@@ -5,11 +5,39 @@ import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springdoc.core.models.GroupedOpenApi
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
 class SwaggerConfig {
+    @Bean
+    fun tftAPI(): GroupedOpenApi {
+        return GroupedOpenApi
+            .builder()
+            .group("TFT")
+            .pathsToMatch("/api/tft/**")
+            .build()
+    }
+
+    @Bean
+    fun accountAPI(): GroupedOpenApi {
+        return GroupedOpenApi
+            .builder()
+            .group("Account")
+            .pathsToMatch("/api/accounts/**")
+            .build()
+    }
+
+    @Bean
+    fun leagueOfLegendAPI(): GroupedOpenApi {
+        return GroupedOpenApi
+            .builder()
+            .group("League of Legend")
+            .pathsToMatch("/api/lol/**")
+            .build()
+    }
+
     @Bean
     fun openAPI(): OpenAPI {
         val jwt = "JWT"

--- a/src/main/kotlin/com/lol/analyzer/aram/riot/infrastructure/RiotApiImpl.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/riot/infrastructure/RiotApiImpl.kt
@@ -17,12 +17,11 @@ import java.util.concurrent.TimeUnit
 // https://docs.spring.io/spring-framework/docs/6.0.0/reference/html/integration.html#rest-http-interface
 @Configuration
 class RiotApiImpl(
-    @Value("\${riot.api-key}")
-    private val riotApiKey: String,
+    @Value("\${riot.tft-api-key}")
+    private val tftApiKey: String,
+    // TODO("LoL API")
 ) {
     companion object {
-        @Value("\${riot.api-key}")
-        lateinit var RIOT_API_KEY: String
         const val RIOT_API_URL = "https://asia.api.riotgames.com"
         const val TIMEOUT_MILLIS = 60000L
     }
@@ -39,7 +38,7 @@ class RiotApiImpl(
         return WebClient
             .builder()
             .baseUrl(RIOT_API_URL)
-            .defaultHeader("X-Riot-Token", riotApiKey)
+            .defaultHeader("X-Riot-Token", tftApiKey)
             .clientConnector(ReactorClientHttpConnector(httpClient()))
             .build()
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,4 +25,4 @@ springdoc:
     tags-sorter: alpha
 
 riot:
-  api-key: ${RIOT_API_KEY}
+  tft-api-key: ${TFT_API_KEY}


### PR DESCRIPTION
## 관련 이슈
- 현재 발급받은 key 는 TFT API 전용
- 추후 발급받을 LoL API Key 를 위해 미리 프로젝트를 TFT / LoL 단위로 분리 

## 작업 내용
- RIOT_API_KEY 명칭을 TFT_API_KEY 로 변경
- Swagger 의 Group API 단위를 LoL / TFT / Account 로 분리 (Account 는 공용)

## Checklist
- [ ] 