### PR TITLE
LolMatch & AccountLolMatch 불러오기 API 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ plugins {
 	id 'org.jetbrains.kotlin.jvm' version '1.9.23'
 	id 'org.jetbrains.kotlin.plugin.spring' version '1.9.23'
 	id 'org.jetbrains.kotlin.plugin.jpa' version '1.9.23'
+	id 'org.jetbrains.kotlin.kapt' version '1.9.23'
 }
 
 group = 'com.lol.analyzer'
@@ -25,8 +26,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'com.fasterxml.jackson.module:jackson-module-kotlin'
 	implementation 'org.jetbrains.kotlin:kotlin-reflect'
-	implementation("org.springframework.boot:spring-boot-starter-webflux")
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+	// querydsl
+	implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
+	kapt("com.querydsl:querydsl-apt:5.0.0:jakarta")
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/kotlin/com/lol/analyzer/aram/account/domain/Account.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/account/domain/Account.kt
@@ -28,7 +28,7 @@ class Account(
         @Column(unique = true)
         @Comment("Aram 서비스 내에서의 uuid")
         var uuid: String? = null,
-):BaseEntity() {
+): BaseEntity() {
         @PrePersist()
         fun setUuid() {
                 this.uuid = UUID.randomUUID().toString()

--- a/src/main/kotlin/com/lol/analyzer/aram/account/domain/Account.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/account/domain/Account.kt
@@ -1,6 +1,8 @@
 package com.lol.analyzer.aram.account.domain
 
 import com.lol.analyzer.aram.common.domain.BaseEntity
+import com.lol.analyzer.aram.lolmatch.domain.AccountLolMatch
+import com.lol.analyzer.aram.lolmatch.domain.LolMatch
 import jakarta.persistence.*
 import org.hibernate.annotations.Comment
 import java.util.UUID
@@ -29,6 +31,11 @@ class Account(
         @Comment("Aram 서비스 내에서의 uuid")
         var uuid: String? = null,
 ): BaseEntity() {
+        @OneToMany(fetch = FetchType.LAZY, mappedBy = "account")
+        private var _accountLolMatches: MutableList<AccountLolMatch> = mutableListOf()
+        val accountLolMatches: List<AccountLolMatch>
+                get() = _accountLolMatches.toList()
+
         @PrePersist()
         fun setUuid() {
                 this.uuid = UUID.randomUUID().toString()

--- a/src/main/kotlin/com/lol/analyzer/aram/account/dto/ExceptionResponse.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/account/dto/ExceptionResponse.kt
@@ -1,8 +1,6 @@
 package com.lol.analyzer.aram.account.dto
 
-import com.lol.analyzer.aram.common.enums.ErrorCode
-import org.springframework.http.HttpStatus
-import org.springframework.http.HttpStatusCode
+import com.lol.analyzer.aram.common.enums._enums.ErrorCode
 
 data class ExceptionResponse(
     val statusCode: Int,

--- a/src/main/kotlin/com/lol/analyzer/aram/account/exception/AccountException.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/account/exception/AccountException.kt
@@ -1,6 +1,6 @@
 package com.lol.analyzer.aram.account.exception
 
-import com.lol.analyzer.aram.common.enums.ErrorCode
+import com.lol.analyzer.aram.common.enums._enums.ErrorCode
 
 open class AccountException(
     override val message: String,

--- a/src/main/kotlin/com/lol/analyzer/aram/account/exception/AccountExceptionHandler.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/account/exception/AccountExceptionHandler.kt
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.reactive.function.client.WebClientResponseException
 
 @RestControllerAdvice(basePackages = ["com.lol.analyzer.aram.account"])
-class ExceptionHandler {
+class AccountExceptionHandler {
     @ExceptionHandler(WebClientResponseException::class)
     fun webClientResponseException(e: WebClientResponseException): ResponseEntity<ExceptionResponse> {
         return ResponseEntity(ExceptionResponse(e.statusCode.value(), ErrorCode.RIOT_RESPONSE_ERROR, e.message), e.statusCode)

--- a/src/main/kotlin/com/lol/analyzer/aram/account/exception/ExceptionHandler.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/account/exception/ExceptionHandler.kt
@@ -1,7 +1,7 @@
 package com.lol.analyzer.aram.account.exception
 
 import com.lol.analyzer.aram.account.dto.ExceptionResponse
-import com.lol.analyzer.aram.common.enums.ErrorCode
+import com.lol.analyzer.aram.common.enums._enums.ErrorCode
 import org.springframework.http.HttpStatusCode
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler

--- a/src/main/kotlin/com/lol/analyzer/aram/account/exception/NotFoundException.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/account/exception/NotFoundException.kt
@@ -1,6 +1,6 @@
 package com.lol.analyzer.aram.account.exception
 
-import com.lol.analyzer.aram.common.enums.ErrorCode
+import com.lol.analyzer.aram.common.enums._enums.ErrorCode
 
 
 class NotFoundException(

--- a/src/main/kotlin/com/lol/analyzer/aram/common/config/QueryDslConfig.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/common/config/QueryDslConfig.kt
@@ -1,0 +1,16 @@
+package com.lol.analyzer.aram.common.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class QueryDslConfig(
+    @PersistenceContext
+    private val entityManager: EntityManager
+) {
+    @Bean
+    fun jpaQueryFactory(): JPAQueryFactory = JPAQueryFactory(this.entityManager)
+}

--- a/src/main/kotlin/com/lol/analyzer/aram/common/enums/_enums/ErrorCode.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/common/enums/_enums/ErrorCode.kt
@@ -1,4 +1,4 @@
-package com.lol.analyzer.aram.common.enums
+package com.lol.analyzer.aram.common.enums._enums
 
 enum class ErrorCode(val code: String) {
     // common

--- a/src/main/kotlin/com/lol/analyzer/aram/common/enums/_enums/GameMode.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/common/enums/_enums/GameMode.kt
@@ -1,0 +1,24 @@
+package com.lol.analyzer.aram.common.enums._enums
+
+enum class GameMode(val gameMode: String, val description: String) {
+    CLASSIC("CLASSIC", "Classic Summoner's Rift and Twisted Treeline games"),
+    ODIN("ODIN", "Dominion/Crystal Scar games"),
+    ARAM("ARAM", "ARAM games"),
+    TUTORIAL("TUTORIAL", "Tutorial games"),
+    URF("URF", "URF games"),
+    DOOM_BOT_STEEMO("DOOMBOTSTEEMO", "Doom Bot games"),
+    ONE_FOR_ALL("ONEFORALL", "One for All games"),
+    ASCENSION("ASCENSION", "Ascension games"),
+    FIRST_BLOOD("FIRSTBLOOD", "Snowdown Showdown games"),
+    KING_PORO("KINGPORO", "Legend of the Poro King games"),
+    SIEGE("SIEGE", "Nexus Siege games"),
+    ASSASSINATE("ASSASSINATE", "Blood Hunt Assassin games"),
+    ARSR("ARSR", "All Random Summoner's Rift games"),
+    DARK_STAR("DARKSTAR", "Dark Star: Singularity games"),
+    STAR_GUARDIAN("STARGUARDIAN", "Star Guardian Invasion games"),
+    PROJECT("PROJECT", "PROJECT: Hunters games"),
+    GAME_MODEX("GAMEMODEX", "Nexus Blitz games"),
+    ODYSSEY("ODYSSEY", "Odyssey: Extraction games"),
+    NEXUS_BLITZ("NEXUSBLITZ", "Nexus Blitz games"),
+    ULT_BOOK("ULTBOOK", "Ultimate Spellbook games")
+}

--- a/src/main/kotlin/com/lol/analyzer/aram/common/enums/_enums/GameType.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/common/enums/_enums/GameType.kt
@@ -1,0 +1,7 @@
+package com.lol.analyzer.aram.common.enums._enums
+
+enum class GameType(val gameType: String, val description: String) {
+    CUSTOM_GAME("CUSTOM_GAME", "Custom games"),
+    TUTORIAL_GAME("TUTORIAL_GAME", "Tutorial games"),
+    MATCHED_GAME("MATCHED_GAME", "all other games")
+}

--- a/src/main/kotlin/com/lol/analyzer/aram/common/enums/_enums/Maps.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/common/enums/_enums/Maps.kt
@@ -1,0 +1,20 @@
+package com.lol.analyzer.aram.common.enums._enums
+
+enum class Maps(val mapId: Int, val mapName: String, val notes: String) {
+    SUMMONERS_RIFT_SUMMER(1, "Summoner's Rift", "Original Summer variant"),
+    SUMMONERS_RIFT_AUTUMN(2, "Summoner's Rift", "Original Autumn variant"),
+    PROVING_GROUND(3, "The Proving Grounds", "Tutorial Map"),
+    TWISTED_TREELINE_ORIGINAL(4, "Twisted Treeline", "Original Version"),
+    CRYSTAL_SCAR(8, "The Crystal Scar", "Dominion map"),
+    TWISTED_TREELINE_TT(10, "Twisted Treeline", "Last TT map"),
+    SUMMONERS_RIFT_AUTUMN_CURRENT(11, "Summoner's Rift", "Current Version"),
+    HOWLING_ABYSS(12, "Howling Abyss",  "ARAM map"),
+    BUTCHERS_BRIDGE(14, "Butcher's Bridge", "Alternate ARAM map"),
+    COSMIC_RUINS(16, "Cosmic Ruins", "Dark Star: Singularity map"),
+    VALORAN_CITY_PARK(18, "Valoran City Park", "Star Guardian Invasion map"),
+    SUBSTRUCTURE_43(19, "Substructure 43", "PROJECT: Hunters map"),
+    CRASH_SITE(20, "Crash Site", "Odyssey: Extraction map"),
+    NEXUS_BLITZ(21, "Nexus Blitz", "Nexus Blitz map"),
+    CONVERGENCE(22, "Convergence", "Teamfight Tactics map"),
+    RINGS_OF_WRATH(30, "Rings of Wrath", "Arena map")
+}

--- a/src/main/kotlin/com/lol/analyzer/aram/common/enums/converter/GameModeConverter.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/common/enums/converter/GameModeConverter.kt
@@ -1,0 +1,12 @@
+package com.lol.analyzer.aram.common.enums.converter
+
+import com.lol.analyzer.aram.common.enums._enums.GameMode
+import jakarta.persistence.AttributeConverter
+import jakarta.persistence.Converter
+
+@Converter
+class GameModeConverter: AttributeConverter<GameMode, String> {
+    override fun convertToDatabaseColumn(attribute: GameMode): String = attribute.gameMode
+
+    override fun convertToEntityAttribute(dbData: String): GameMode = GameMode.entries.first { it.gameMode == dbData }
+}

--- a/src/main/kotlin/com/lol/analyzer/aram/common/enums/converter/GameTypeConverter.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/common/enums/converter/GameTypeConverter.kt
@@ -1,0 +1,12 @@
+package com.lol.analyzer.aram.common.enums.converter
+
+import com.lol.analyzer.aram.common.enums._enums.GameType
+import jakarta.persistence.AttributeConverter
+import jakarta.persistence.Converter
+
+@Converter
+class GameTypeConverter: AttributeConverter<GameType, String> {
+    override fun convertToDatabaseColumn(attribute: GameType): String = attribute.gameType
+
+    override fun convertToEntityAttribute(dbData: String): GameType = GameType.entries.first { it.gameType == dbData }
+}

--- a/src/main/kotlin/com/lol/analyzer/aram/common/enums/converter/MapsConverter.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/common/enums/converter/MapsConverter.kt
@@ -1,0 +1,12 @@
+package com.lol.analyzer.aram.common.enums.converter
+
+import com.lol.analyzer.aram.common.enums._enums.Maps
+import jakarta.persistence.AttributeConverter
+import jakarta.persistence.Converter
+
+@Converter
+class MapsConverter: AttributeConverter<Maps, Int> {
+    override fun convertToDatabaseColumn(attribute: Maps): Int = attribute.mapId
+
+    override fun convertToEntityAttribute(dbData: Int): Maps = Maps.entries.first { it.mapId == dbData }
+}

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/application/LolMatchService.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/application/LolMatchService.kt
@@ -1,54 +1,92 @@
 package com.lol.analyzer.aram.lolmatch.application
 
+import com.lol.analyzer.aram.account.domain.AccountRepository
 import com.lol.analyzer.aram.lolmatch.domain.AccountLolMatch
 import com.lol.analyzer.aram.lolmatch.domain.LolMatch
 import com.lol.analyzer.aram.lolmatch.domain.LolMatchCustomRepository
 import com.lol.analyzer.aram.lolmatch.dto.command.LoadLolMatchCommand
+import com.lol.analyzer.aram.lolmatch.dto.response.LoadLolMatchResponse
 import com.lol.analyzer.aram.riot.domain.LolApi
+import jakarta.transaction.Transactional
 import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException
+import org.springframework.http.HttpStatusCode
 import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClientResponseException
 
 @Service
 class LolMatchService(
     private val lolMatchRepository: LolMatchCustomRepository,
+    private val accountRepository: AccountRepository, // TODO: refactor
     private val lolApi: LolApi,
 ) {
-    fun loadLolMatchesByPuuid(loadLolMatchCommand: LoadLolMatchCommand): List<LolMatch> {
+    @Transactional
+    fun loadLolMatchesByUuid(loadLolMatchCommand: LoadLolMatchCommand): List<LoadLolMatchResponse> {
+        val account = this.accountRepository.findByUuid(loadLolMatchCommand.uuid) ?: throw NotFoundException()
         val lolMatches = this.lolMatchRepository.getLolMatchesByAccountPuuid(
-            puuid = loadLolMatchCommand.puuid,
+            puuid = account.puuid,
             cursor = loadLolMatchCommand.cursor,
             count = loadLolMatchCommand.count
-        )
+        ).toMutableList()
 
-        if (lolMatches.size == loadLolMatchCommand.count) return lolMatches
-
-        val (totalCount, lastId) = this.lolMatchRepository.getLolMatchesCountAndLastLolMatchId(loadLolMatchCommand.puuid)
-        var lolMatchIds = this.lolApi.getLolMatchesByPuuid(
-            loadLolMatchCommand.puuid,
-            totalCount,
-            2 * loadLolMatchCommand.count // load double
-        )
-        if (lastId != null) { lolMatchIds = lolMatchIds.filter { it < lastId } }
-
-        lolMatchIds.forEach {
-            val (metadata, info) = this.lolApi.getLolMatchByMatchId(it)
-            val participant = info.participants.find { it.puuid == loadLolMatchCommand.puuid } ?: throw NotFoundException()
-
-            val lolMatch = LolMatch(
-                matchId = metadata.matchId,
-                mapId = info.mapId,
-                gameMode = info.gameMode,
-                gameType = info.gameType,
-                gameEndTimestamp = info.gameEndTimestamp,
-                gameStartTimestamp = info.gameStartTimestamp
+        if (lolMatches.size != loadLolMatchCommand.count) {
+            val (totalCount, lastId) = this.lolMatchRepository.getLolMatchesCountAndLastLolMatchId(account.puuid)
+            var lolMatchIds = this.lolApi.getLolMatchesByPuuid(
+                account.puuid,
+                totalCount,
+                2 * loadLolMatchCommand.count // load double
             )
+            if (lastId != null) { lolMatchIds = lolMatchIds.filter { it < lastId } }
 
-//            val accountLolMatch = AccountLolMatch(
-//                lane = participant.lane,
-//                physicalDamageDealt = participant.physicalDamageDealt,
-//            )
+            lolMatchIds.forEach { matchId ->
+                try {
+                    val (metadata, info) = this.lolApi.getLolMatchByMatchId(matchId)
+
+                    val participant = info.participants.find { p -> p.puuid == account.puuid } ?: throw NotFoundException()
+
+                    val lolMatch = this.lolMatchRepository.getLolMatchByMatchId(matchId) ?: LolMatch(
+                        matchId = metadata.matchId,
+                        mapId = info.mapId,
+                        gameMode = info.gameMode,
+                        gameType = info.gameType,
+                        gameEndTimestamp = info.gameEndTimestamp,
+                        gameStartTimestamp = info.gameStartTimestamp
+                    )
+
+                    val accountLolMatch = AccountLolMatch(
+                        account = account,
+                        lolMatch = lolMatch,
+                        lane = participant.lane,
+                        physicalDamageDealt = participant.physicalDamageDealt,
+                        physicalDamageDealtToChampions = participant.physicalDamageDealtToChampions,
+                        physicalDamageTaken = participant.physicalDamageTaken,
+                        magicDamageDealt = participant.magicDamageDealt,
+                        magicDamageDealtToChampions = participant.magicDamageDealtToChampions,
+                        magicDamageTaken = participant.magicDamageTaken,
+                        championName = participant.championName,
+                        kills = participant.kills,
+                        deaths = participant.deaths,
+                        assists = participant.assists,
+                        win = participant.win,
+                        item0 = participant.item0,
+                        item1 = participant.item1,
+                        item2 = participant.item2,
+                        item3 = participant.item3,
+                        item4 = participant.item4,
+                        item5 = participant.item5
+                    )
+                    lolMatch.addAccountLolMatch(accountLolMatch)
+
+                    this.lolMatchRepository.save(lolMatch)
+
+                    if (lolMatches.size < loadLolMatchCommand.count) { lolMatches.add(lolMatch) }
+                } catch (e: WebClientResponseException) {
+                    if (e.statusCode != HttpStatusCode.valueOf(404)) {
+                        throw IllegalArgumentException()
+                    }
+                }
+            }
         }
 
-        return lolMatches
+        return lolMatches.map { lolMatch ->  LoadLolMatchResponse.from(lolMatch) }
     }
 }

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/application/LolMatchService.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/application/LolMatchService.kt
@@ -90,9 +90,6 @@ class LolMatchService(
 
         val data = lolMatches.map { lolMatch ->  LoadLolMatchResponse.from(lolMatch) }
 
-        return LoadLolMatchesByUuidResponse(
-            count = data.size,
-            data = data
-        )
+        return LoadLolMatchesByUuidResponse(data)
     }
 }

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/application/LolMatchService.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/application/LolMatchService.kt
@@ -1,0 +1,17 @@
+package com.lol.analyzer.aram.lolmatch.application
+
+import com.lol.analyzer.aram.lolmatch.domain.AccountLolMatchRepository
+import com.lol.analyzer.aram.riot.domain.LolApi
+import org.springframework.stereotype.Service
+
+@Service
+class LolMatchService(
+    private val accountLolMatchRepository: AccountLolMatchRepository,
+    private val lolApi: LolApi,
+) {
+    fun loadLolMatchesByPuuid(puuid: String): List<String> {
+        val lolMatchIds = this.lolApi.getLolMatchesByPuuid(puuid)
+
+        return lolMatchIds
+    }
+}

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/application/LolMatchService.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/application/LolMatchService.kt
@@ -1,17 +1,43 @@
 package com.lol.analyzer.aram.lolmatch.application
 
-import com.lol.analyzer.aram.lolmatch.domain.AccountLolMatchRepository
+import com.lol.analyzer.aram.lolmatch.domain.LolMatch
+import com.lol.analyzer.aram.lolmatch.domain.LolMatchCustomRepository
+import com.lol.analyzer.aram.lolmatch.dto.command.LoadLolMatchCommand
 import com.lol.analyzer.aram.riot.domain.LolApi
 import org.springframework.stereotype.Service
 
 @Service
 class LolMatchService(
-    private val accountLolMatchRepository: AccountLolMatchRepository,
+    private val lolMatchRepository: LolMatchCustomRepository,
     private val lolApi: LolApi,
 ) {
-    fun loadLolMatchesByPuuid(puuid: String): List<String> {
-        val lolMatchIds = this.lolApi.getLolMatchesByPuuid(puuid)
+    fun loadLolMatchesByPuuid(loadLolMatchCommand: LoadLolMatchCommand): List<LolMatch> {
+        // TODO(startIndex & count 개수만큼 불러오기)
+        val lolMatches = this.lolMatchRepository.getLolMatchesByAccountPuuid(
+            puuid = loadLolMatchCommand.puuid,
+            cursor = loadLolMatchCommand.cursor,
+            count = loadLolMatchCommand.count
+        )
 
-        return lolMatchIds
+        // TODO count 개수만큼 잘 불러왔다면 바로 리턴
+        if (lolMatches.size == loadLolMatchCommand.count) return lolMatches
+
+        // TODO(매치 전체 개수와 마지막 matchId 를 불러오는 api 작성)
+        var (totalCount, lastId) = this.lolMatchRepository.getLolMatchesCountAndLastLolMatchId(loadLolMatchCommand.puuid)
+        var lolMatchIds = this.lolApi.getLolMatchesByPuuid(
+            loadLolMatchCommand.puuid,
+            totalCount,
+            2 * loadLolMatchCommand.count // load double
+        )
+
+        if (lastId != null) { lolMatchIds = lolMatchIds.filter { it < lastId } }
+
+        // TODO lolMatchIds 중 마지막 matchId 보다 적은 것 (오래된 것) 들 filter
+        lolMatchIds.forEach {
+            var lolMatchResponse = this.lolApi.getLolMatchByMatchId(it)
+            println(it)
+        }
+
+        return lolMatches
     }
 }

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/domain/AccountLolMatch.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/domain/AccountLolMatch.kt
@@ -8,7 +8,7 @@ import jakarta.persistence.*
 @Entity
 @Table(name = "account_lol_matches")
 class AccountLolMatch(
-    @Column(length = 20) // TODO enum
+    @Column(length = 20)
     var lane: String,
 
     @Column(name = "physical_damage_dealt")

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/domain/AccountLolMatch.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/domain/AccountLolMatch.kt
@@ -1,16 +1,13 @@
 package com.lol.analyzer.aram.lolmatch.domain
 
+import com.lol.analyzer.aram.account.domain.Account
 import com.lol.analyzer.aram.common.domain.BaseEntity
-import jakarta.persistence.Column
-import jakarta.persistence.Entity
-import jakarta.persistence.ManyToOne
-import jakarta.persistence.Table
+import jakarta.persistence.*
 
+// https://spoqa.github.io/2022/08/16/kotlin-jpa-entity.html
 @Entity
-@Table
+@Table(name = "account_lol_matches")
 class AccountLolMatch(
-    @ManyToOne()
-
     @Column(length = 20) // TODO enum
     var lane: String,
 
@@ -64,5 +61,16 @@ class AccountLolMatch(
 
     @Column(name = "item_5")
     var item5: Int,
+
+    account: Account,
+
+    lolMatch: LolMatch,
 ): BaseEntity() {
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "lol_match_id", nullable = false)
+    var lolMatch: LolMatch = lolMatch
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "account_id", nullable = false)
+    var account: Account = account
 }

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/domain/AccountLolMatch.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/domain/AccountLolMatch.kt
@@ -1,0 +1,68 @@
+package com.lol.analyzer.aram.lolmatch.domain
+
+import com.lol.analyzer.aram.common.domain.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table
+class AccountLolMatch(
+    @ManyToOne()
+
+    @Column(length = 20) // TODO enum
+    var lane: String,
+
+    @Column(name = "physical_damage_dealt")
+    var physicalDamageDealt: Int,
+
+    @Column(name = "physical_damage_dealt_to_champions")
+    var physicalDamageDealtToChampions: Int,
+
+    @Column(name = "physical_damage_taken")
+    var physicalDamageTaken: Int,
+
+    @Column(name = "magic_damage_dealt")
+    var magicDamageDealt: Int,
+
+    @Column(name = "magic_damage_dealt_to_champions")
+    var magicDamageDealtToChampions: Int,
+
+    @Column(name = "magic_damage_taken")
+    var magicDamageTaken: Int,
+
+    @Column(name = "champion_name", length = 20)
+    var championName: String,
+
+    @Column
+    var kills: Int,
+
+    @Column
+    var deaths: Int,
+
+    @Column
+    var assists: Int,
+
+    @Column
+    var win: Boolean,
+
+    @Column(name = "item_0")
+    var item0: Int,
+
+    @Column(name = "item_1")
+    var item1: Int,
+
+    @Column(name = "item_2")
+    var item2: Int,
+
+    @Column(name = "item_3")
+    var item3: Int,
+
+    @Column(name = "item_4")
+    var item4: Int,
+
+    @Column(name = "item_5")
+    var item5: Int,
+): BaseEntity() {
+}

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/domain/LolMatch.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/domain/LolMatch.kt
@@ -1,0 +1,36 @@
+package com.lol.analyzer.aram.lolmatch.domain
+
+import com.lol.analyzer.aram.common.domain.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+
+@Entity
+@Table(
+    name = "lol_matches",
+    indexes = [
+        Index(name = "idx_match_id", columnList = "matchId", unique = true),
+        Index(name = "idx_game_start_timestamp", columnList = "gameStartTimestamp"),
+    ]
+)
+class LolMatch(
+    @Column(name = "match_id")
+    var matchId: String,
+
+    @Column(name = "map_id")
+    var mapId: Int,
+
+    @Column(name = "game_mode")
+    var gameMode: String,
+
+    @Column(name = "game_type")
+    var gameType: String,
+
+    @Column(name = "game_start_timestamp")
+    var gameStartTimestamp: Long,
+
+    @Column(name = "game_end_timestamp")
+    var gameEndTimestamp: Long
+): BaseEntity() {
+}

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/domain/LolMatch.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/domain/LolMatch.kt
@@ -1,6 +1,9 @@
 package com.lol.analyzer.aram.lolmatch.domain
 
 import com.lol.analyzer.aram.common.domain.BaseEntity
+import com.lol.analyzer.aram.common.enums._enums.GameMode
+import com.lol.analyzer.aram.common.enums._enums.GameType
+import com.lol.analyzer.aram.common.enums.converter.*
 import jakarta.persistence.*
 
 @Entity
@@ -11,18 +14,21 @@ import jakarta.persistence.*
         Index(name = "idx_game_start_timestamp", columnList = "gameStartTimestamp"),
     ]
 )
+@Convert(converter = MapsConverter::class, attributeName = "mapId")
+@Convert(converter = GameModeConverter::class, attributeName = "gameMode")
+@Convert(converter = GameTypeConverter::class, attributeName = "gameType")
 class LolMatch(
     @Column(name = "match_id", length = 30)
     var matchId: String,
 
-    @Column(name = "map_id") // TODO enum
+    @Column(name = "map_id")
     var mapId: Int,
 
-    @Column(name = "game_mode", length = 30) // TODO enum
-    var gameMode: String,
+    @Column(name = "game_mode", length = 30)
+    var gameMode: GameMode,
 
-    @Column(name = "game_type", length = 20) // TODO enum
-    var gameType: String,
+    @Column(name = "game_type", length = 20)
+    var gameType: GameType,
 
     @Column(name = "game_start_timestamp")
     var gameStartTimestamp: Long,

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/domain/LolMatch.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/domain/LolMatch.kt
@@ -15,16 +15,16 @@ import jakarta.persistence.Table
     ]
 )
 class LolMatch(
-    @Column(name = "match_id")
+    @Column(name = "match_id", length = 30)
     var matchId: String,
 
-    @Column(name = "map_id")
+    @Column(name = "map_id") // TODO enum
     var mapId: Int,
 
-    @Column(name = "game_mode")
+    @Column(name = "game_mode", length = 30) // TODO enum
     var gameMode: String,
 
-    @Column(name = "game_type")
+    @Column(name = "game_type", length = 20) // TODO enum
     var gameType: String,
 
     @Column(name = "game_start_timestamp")

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/domain/LolMatch.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/domain/LolMatch.kt
@@ -1,10 +1,7 @@
 package com.lol.analyzer.aram.lolmatch.domain
 
 import com.lol.analyzer.aram.common.domain.BaseEntity
-import jakarta.persistence.Column
-import jakarta.persistence.Entity
-import jakarta.persistence.Index
-import jakarta.persistence.Table
+import jakarta.persistence.*
 
 @Entity
 @Table(
@@ -31,6 +28,10 @@ class LolMatch(
     var gameStartTimestamp: Long,
 
     @Column(name = "game_end_timestamp")
-    var gameEndTimestamp: Long
+    var gameEndTimestamp: Long,
 ): BaseEntity() {
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "lolMatch")
+    private var _accountLolMatches: MutableList<AccountLolMatch> = mutableListOf()
+    val accountLolMatches: List<AccountLolMatch>
+        get() = _accountLolMatches.toList()
 }

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/domain/LolMatch.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/domain/LolMatch.kt
@@ -3,6 +3,7 @@ package com.lol.analyzer.aram.lolmatch.domain
 import com.lol.analyzer.aram.common.domain.BaseEntity
 import com.lol.analyzer.aram.common.enums._enums.GameMode
 import com.lol.analyzer.aram.common.enums._enums.GameType
+import com.lol.analyzer.aram.common.enums._enums.Maps
 import com.lol.analyzer.aram.common.enums.converter.*
 import jakarta.persistence.*
 
@@ -22,7 +23,7 @@ class LolMatch(
     var matchId: String,
 
     @Column(name = "map_id")
-    var mapId: Int,
+    var mapId: Maps,
 
     @Column(name = "game_mode", length = 30)
     var gameMode: GameMode,
@@ -36,8 +37,12 @@ class LolMatch(
     @Column(name = "game_end_timestamp")
     var gameEndTimestamp: Long,
 ): BaseEntity() {
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "lolMatch")
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "lolMatch", cascade = [CascadeType.PERSIST, CascadeType.REMOVE])
     private var _accountLolMatches: MutableList<AccountLolMatch> = mutableListOf()
     val accountLolMatches: List<AccountLolMatch>
         get() = _accountLolMatches.toList()
+
+    fun addAccountLolMatch(accountLolMatch: AccountLolMatch) {
+        this._accountLolMatches.add(accountLolMatch)
+    }
 }

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/domain/LolMatchCustomRepository.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/domain/LolMatchCustomRepository.kt
@@ -6,4 +6,7 @@ interface LolMatchCustomRepository {
     fun getLolMatchesByAccountPuuid(puuid: String, cursor: Long, count : Int): List<LolMatch>
 
     fun getLolMatchesCountAndLastLolMatchId(puuid: String): Pair<Int, String?>
+    fun saveLolMatch(
+
+    )
 }

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/domain/LolMatchCustomRepository.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/domain/LolMatchCustomRepository.kt
@@ -1,12 +1,11 @@
 package com.lol.analyzer.aram.lolmatch.domain
 
-import org.springframework.data.jpa.repository.JpaRepository
-
 interface LolMatchCustomRepository {
+    fun getLolMatchByMatchId(matchId: String): LolMatch?
+
     fun getLolMatchesByAccountPuuid(puuid: String, cursor: Long, count : Int): List<LolMatch>
 
     fun getLolMatchesCountAndLastLolMatchId(puuid: String): Pair<Int, String?>
-    fun saveLolMatch(
 
-    )
+    fun save(lolMatch: LolMatch)
 }

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/domain/LolMatchCustomRepository.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/domain/LolMatchCustomRepository.kt
@@ -1,0 +1,9 @@
+package com.lol.analyzer.aram.lolmatch.domain
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface LolMatchCustomRepository {
+    fun getLolMatchesByAccountPuuid(puuid: String, cursor: Long, count : Int): List<LolMatch>
+
+    fun getLolMatchesCountAndLastLolMatchId(puuid: String): Pair<Int, String?>
+}

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/dto/command/LoadLolMatchCommand.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/dto/command/LoadLolMatchCommand.kt
@@ -1,7 +1,7 @@
 package com.lol.analyzer.aram.lolmatch.dto.command
 
 data class LoadLolMatchCommand(
-    val puuid: String,
+    val uuid: String,
     val cursor: Long,
     val count: Int
 )

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/dto/command/LoadLolMatchCommand.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/dto/command/LoadLolMatchCommand.kt
@@ -1,0 +1,7 @@
+package com.lol.analyzer.aram.lolmatch.dto.command
+
+data class LoadLolMatchCommand(
+    val puuid: String,
+    val cursor: Long,
+    val count: Int
+)

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/dto/request/LoadLolMatchRequest.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/dto/request/LoadLolMatchRequest.kt
@@ -6,14 +6,14 @@ import io.swagger.v3.oas.annotations.media.Schema
 @Schema(name = "Load Lol Match Request", description = "LoL Match 불러오기 요청")
 data class LoadLolMatchRequest(
     @Schema(description = "Account 의 lol puuid", example = "puuid", required = true)
-    val puuid: String,
+    val uuid: String,
     @Schema(description = "커서 ID", example = "0", required = false)
     val cursor: Long = 0,
     @Schema(description = "데이터 개수", example = "0", required = false)
     val count: Int = 20,
 ) {
     fun toCommand() = LoadLolMatchCommand(
-        puuid = this.puuid,
+        uuid = this.uuid,
         cursor = this.cursor,
         count = this.count
     )

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/dto/request/LoadLolMatchRequest.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/dto/request/LoadLolMatchRequest.kt
@@ -1,0 +1,20 @@
+package com.lol.analyzer.aram.lolmatch.dto.request
+
+import com.lol.analyzer.aram.lolmatch.dto.command.LoadLolMatchCommand
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(name = "Load Lol Match Request", description = "LoL Match 불러오기 요청")
+data class LoadLolMatchRequest(
+    @Schema(description = "Account 의 lol puuid", example = "puuid", required = true)
+    val puuid: String,
+    @Schema(description = "커서 ID", example = "0", required = false)
+    val cursor: Long = 0,
+    @Schema(description = "데이터 개수", example = "0", required = false)
+    val count: Int = 20,
+) {
+    fun toCommand() = LoadLolMatchCommand(
+        puuid = this.puuid,
+        cursor = this.cursor,
+        count = this.count
+    )
+}

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/dto/response/LoadAccountLolMatchResponse.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/dto/response/LoadAccountLolMatchResponse.kt
@@ -1,0 +1,67 @@
+package com.lol.analyzer.aram.lolmatch.dto.response
+
+import com.lol.analyzer.aram.lolmatch.domain.AccountLolMatch
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(name = "Load Account Lol Match", description = "LoL Account Match 불러오기")
+data class LoadAccountLolMatchResponse(
+    @Schema(description = "라인", example = "TOP")
+    val lane: String,
+    @Schema(description = "가한 총 물리데미지")
+    val physicalDamageDealt: Int,
+    @Schema(description = "챔피언에 가한 물리데미지")
+    val physicalDamageDealtToChampions: Int,
+    @Schema(description = "받은 물리데미지")
+    val physicalDamageTaken: Int,
+    @Schema(description = "가한 마법데미지")
+    val magicDamageDealt: Int,
+    @Schema(description = "챔피언에 가한 마법데미지")
+    val magicDamageDealtToChampions: Int,
+    @Schema(description = "받은 마법데미지")
+    val magicDamageTaken: Int,
+    @Schema(description = "플레이한 챔피언")
+    val championName: String,
+    @Schema(description = "킬 수")
+    val kills: Int,
+    @Schema(description = "데스 수")
+    val deaths: Int,
+    @Schema(description = "어시스트 수")
+    val assists: Int,
+    @Schema(description = "게임 승리 여부")
+    val win: Boolean,
+    @Schema(description = "첫번째 아이템")
+    val item0: Int,
+    @Schema(description = "두번째 아이템")
+    val item1: Int,
+    @Schema(description = "세번째 아이템")
+    val item2: Int,
+    @Schema(description = "네번째 아이템")
+    val item3: Int,
+    @Schema(description = "다섯번째 아이템")
+    val item4: Int,
+    @Schema(description = "여섯번째 아이템")
+    val item5: Int,
+) {
+    companion object {
+        fun from(accountLolMatch: AccountLolMatch) = LoadAccountLolMatchResponse(
+            lane = accountLolMatch.lane,
+            physicalDamageDealt = accountLolMatch.physicalDamageDealt,
+            physicalDamageDealtToChampions = accountLolMatch.physicalDamageDealtToChampions,
+            physicalDamageTaken = accountLolMatch.physicalDamageTaken,
+            magicDamageDealt = accountLolMatch.magicDamageDealt,
+            magicDamageDealtToChampions = accountLolMatch.magicDamageDealtToChampions,
+            magicDamageTaken = accountLolMatch.magicDamageTaken,
+            championName = accountLolMatch.championName,
+            kills = accountLolMatch.kills,
+            deaths = accountLolMatch.deaths,
+            assists = accountLolMatch.assists,
+            win = accountLolMatch.win,
+            item0 = accountLolMatch.item0,
+            item1 = accountLolMatch.item1,
+            item2 = accountLolMatch.item2,
+            item3 = accountLolMatch.item3,
+            item4 = accountLolMatch.item4,
+            item5 = accountLolMatch.item5,
+        )
+    }
+}

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/dto/response/LoadLolMatchResponse.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/dto/response/LoadLolMatchResponse.kt
@@ -5,6 +5,8 @@ import com.lol.analyzer.aram.common.enums._enums.GameType
 import com.lol.analyzer.aram.common.enums._enums.Maps
 import com.lol.analyzer.aram.lolmatch.domain.LolMatch
 import io.swagger.v3.oas.annotations.media.Schema
+import java.text.SimpleDateFormat
+import java.util.*
 
 @Schema(name = "Load Lol Match", description = "LoL Match 불러오기")
 data class LoadLolMatchResponse(
@@ -17,11 +19,11 @@ data class LoadLolMatchResponse(
     @Schema(description = "게임 타입")
     val gameType: GameType,
     @Schema(description = "게임 시작시간")
-    val gameStartTimestamp: Long,
+    val gameStartTimestamp: String,
     @Schema(description = "게임 종료시간")
-    val gameEndTimestamp: Long,
+    val gameEndTimestamp: String,
     @Schema(description = "계정 정보")
-    val accountLolMatches: List<LoadAccountLolMatchResponse> = listOf()
+    val accounts: List<LoadAccountLolMatchResponse> = listOf()
 ) {
     companion object {
         fun from(lolMatch: LolMatch) = LoadLolMatchResponse(
@@ -29,9 +31,15 @@ data class LoadLolMatchResponse(
             mapId = lolMatch.mapId,
             gameMode = lolMatch.gameMode,
             gameType = lolMatch.gameType,
-            gameStartTimestamp = lolMatch.gameStartTimestamp,
-            gameEndTimestamp = lolMatch.gameEndTimestamp,
-            accountLolMatches = lolMatch.accountLolMatches.map { LoadAccountLolMatchResponse.from(it) }
+            gameStartTimestamp = toDate(lolMatch.gameStartTimestamp),
+            gameEndTimestamp = toDate(lolMatch.gameEndTimestamp),
+            accounts = lolMatch.accountLolMatches.map { LoadAccountLolMatchResponse.from(it) }
         )
+
+        private fun toDate(timestamp: Long): String {
+            val date = Date(timestamp)
+            val f = SimpleDateFormat("yyyy/MM/dd HH:mm", Locale.KOREA)
+            return f.format(date)
+        }
     }
 }

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/dto/response/LoadLolMatchResponse.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/dto/response/LoadLolMatchResponse.kt
@@ -1,0 +1,37 @@
+package com.lol.analyzer.aram.lolmatch.dto.response
+
+import com.lol.analyzer.aram.common.enums._enums.GameMode
+import com.lol.analyzer.aram.common.enums._enums.GameType
+import com.lol.analyzer.aram.common.enums._enums.Maps
+import com.lol.analyzer.aram.lolmatch.domain.LolMatch
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(name = "Load Lol Match", description = "LoL Match 불러오기")
+data class LoadLolMatchResponse(
+    @Schema(description = "매치 ID")
+    val matchId: String,
+    @Schema(description = "맵 ID")
+    val mapId: Maps,
+    @Schema(description = "게임 모드")
+    val gameMode: GameMode,
+    @Schema(description = "게임 타입")
+    val gameType: GameType,
+    @Schema(description = "게임 시작시간")
+    val gameStartTimestamp: Long,
+    @Schema(description = "게임 종료시간")
+    val gameEndTimestamp: Long,
+    @Schema(description = "계정 정보")
+    val accountLolMatches: List<LoadAccountLolMatchResponse> = listOf()
+) {
+    companion object {
+        fun from(lolMatch: LolMatch) = LoadLolMatchResponse(
+            matchId = lolMatch.matchId,
+            mapId = lolMatch.mapId,
+            gameMode = lolMatch.gameMode,
+            gameType = lolMatch.gameType,
+            gameStartTimestamp = lolMatch.gameStartTimestamp,
+            gameEndTimestamp = lolMatch.gameEndTimestamp,
+            accountLolMatches = lolMatch.accountLolMatches.map { LoadAccountLolMatchResponse.from(it) }
+        )
+    }
+}

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/dto/response/LoadLolMatchesByUuidResponse.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/dto/response/LoadLolMatchesByUuidResponse.kt
@@ -1,0 +1,7 @@
+package com.lol.analyzer.aram.lolmatch.dto.response
+
+data class LoadLolMatchesByUuidResponse(
+    val count: Int,
+    val data: List<LoadLolMatchResponse> = listOf()
+) {
+}

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/dto/response/LoadLolMatchesByUuidResponse.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/dto/response/LoadLolMatchesByUuidResponse.kt
@@ -1,7 +1,7 @@
 package com.lol.analyzer.aram.lolmatch.dto.response
 
 data class LoadLolMatchesByUuidResponse(
-    val count: Int,
-    val data: List<LoadLolMatchResponse> = listOf()
+    val data: List<LoadLolMatchResponse> = listOf(),
+    val count: Int = data.size
 ) {
 }

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/exception/LolMatchExceptionHandler.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/exception/LolMatchExceptionHandler.kt
@@ -1,0 +1,16 @@
+package com.lol.analyzer.aram.lolmatch.exception
+
+import com.lol.analyzer.aram.account.dto.ExceptionResponse
+import com.lol.analyzer.aram.common.enums._enums.ErrorCode
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.reactive.function.client.WebClientResponseException
+
+@RestControllerAdvice(basePackages = ["com.lol.analyzer.aram.lolmatch"])
+class LolMatchExceptionHandler {
+    @ExceptionHandler(WebClientResponseException::class)
+    fun webClientResponseException(e: WebClientResponseException): ResponseEntity<ExceptionResponse> {
+        return ResponseEntity(ExceptionResponse(e.statusCode.value(), ErrorCode.RIOT_RESPONSE_ERROR, e.message), e.statusCode)
+    }
+}

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/infrastructure/LolMatchCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/infrastructure/LolMatchCustomRepositoryImpl.kt
@@ -1,0 +1,57 @@
+package com.lol.analyzer.aram.lolmatch.infrastructure
+
+import com.lol.analyzer.aram.account.domain.QAccount
+import com.lol.analyzer.aram.lolmatch.domain.LolMatch
+import com.lol.analyzer.aram.lolmatch.domain.LolMatchCustomRepository
+import com.lol.analyzer.aram.lolmatch.domain.QAccountLolMatch
+import com.lol.analyzer.aram.lolmatch.domain.QLolMatch
+import com.querydsl.core.Tuple
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.stereotype.Repository
+
+@Repository
+class LolMatchCustomRepositoryImpl(
+    private val jpaQueryFactory: JPAQueryFactory,
+): LolMatchCustomRepository {
+    override fun getLolMatchesByAccountPuuid(
+        puuid: String,
+        cursor: Long,
+        count: Int
+    ): List<LolMatch> {
+        val qAccount = QAccount.account // TODO 여기에 있는것이 맞나.. 구조 확인
+        val qLolMatch = QLolMatch.lolMatch
+        val qAccountLolMatch = QAccountLolMatch.accountLolMatch
+
+        val query = jpaQueryFactory
+            .selectFrom(qLolMatch)
+            .innerJoin(qLolMatch._accountLolMatches, qAccountLolMatch)
+            .innerJoin(qAccountLolMatch.account, qAccount).on(qAccount.puuid.eq(puuid))
+            .where(qLolMatch.id.gt(cursor + 1))
+            .limit(count.toLong())
+
+        return query.fetch()
+    }
+
+    override fun getLolMatchesCountAndLastLolMatchId(puuid: String): Pair<Int, String?> {
+        val qAccount = QAccount.account // TODO 여기에 있는것이 맞나.. 구조 확인
+        val qLolMatch = QLolMatch.lolMatch
+        val qAccountLolMatch = QAccountLolMatch.accountLolMatch
+
+        val count = jpaQueryFactory
+            .selectFrom(qLolMatch)
+            .select(qLolMatch.count())
+            .innerJoin(qLolMatch._accountLolMatches, qAccountLolMatch)
+            .innerJoin(qAccountLolMatch.account, qAccount).on(qAccount.puuid.eq(puuid))
+            .fetchFirst()
+
+        val lastId = jpaQueryFactory
+            .selectFrom(qLolMatch)
+            .select(qLolMatch.matchId)
+            .innerJoin(qLolMatch._accountLolMatches, qAccountLolMatch)
+            .innerJoin(qAccountLolMatch.account, qAccount).on(qAccount.puuid.eq(puuid))
+            .orderBy(qLolMatch.id.desc())
+            .fetchOne()
+
+        return Pair(count.toInt(), lastId)
+    }
+}

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/infrastructure/LolMatchCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/infrastructure/LolMatchCustomRepositoryImpl.kt
@@ -30,10 +30,9 @@ class LolMatchCustomRepositoryImpl(
         val qLolMatch = QLolMatch.lolMatch
         val qAccountLolMatch = QAccountLolMatch.accountLolMatch
 
-        // TODO: fix N+1
         val query = jpaQueryFactory
             .selectFrom(qLolMatch)
-            .innerJoin(qLolMatch._accountLolMatches, qAccountLolMatch)
+            .innerJoin(qLolMatch._accountLolMatches, qAccountLolMatch).fetchJoin()
             .innerJoin(qAccountLolMatch.account, qAccount).on(qAccount.puuid.eq(puuid))
             .where(qLolMatch.id.gt(cursor))
             .limit(count.toLong())

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/presentation/LolMatchController.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/presentation/LolMatchController.kt
@@ -3,6 +3,7 @@ package com.lol.analyzer.aram.lolmatch.presentation
 import com.lol.analyzer.aram.lolmatch.application.LolMatchService
 import com.lol.analyzer.aram.lolmatch.domain.LolMatch
 import com.lol.analyzer.aram.lolmatch.dto.request.LoadLolMatchRequest
+import com.lol.analyzer.aram.lolmatch.dto.response.LoadLolMatchResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.PostMapping
@@ -16,9 +17,9 @@ import org.springframework.web.bind.annotation.RestController
 class LolMatchController(
     private val lolMatchService: LolMatchService
 ) {
-    @PostMapping("/by-puuid")
-    @Operation(description = "PUUID 로 LoL Match 불러오기")
-    fun loadLolMatchesByPuuid(@RequestBody loadLolMatchRequest: LoadLolMatchRequest): List<LolMatch> {
-        return this.lolMatchService.loadLolMatchesByPuuid(loadLolMatchRequest.toCommand())
+    @PostMapping("/by-uuid")
+    @Operation(description = "UUID 로 LoL Match 불러오기")
+    fun loadLolMatchesByUuid(@RequestBody loadLolMatchRequest: LoadLolMatchRequest): List<LoadLolMatchResponse> {
+        return this.lolMatchService.loadLolMatchesByUuid(loadLolMatchRequest.toCommand())
     }
 }

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/presentation/LolMatchController.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/presentation/LolMatchController.kt
@@ -1,9 +1,8 @@
 package com.lol.analyzer.aram.lolmatch.presentation
 
 import com.lol.analyzer.aram.lolmatch.application.LolMatchService
-import com.lol.analyzer.aram.lolmatch.domain.LolMatch
 import com.lol.analyzer.aram.lolmatch.dto.request.LoadLolMatchRequest
-import com.lol.analyzer.aram.lolmatch.dto.response.LoadLolMatchResponse
+import com.lol.analyzer.aram.lolmatch.dto.response.LoadLolMatchesByUuidResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.PostMapping
@@ -19,7 +18,7 @@ class LolMatchController(
 ) {
     @PostMapping("/by-uuid")
     @Operation(description = "UUID 로 LoL Match 불러오기")
-    fun loadLolMatchesByUuid(@RequestBody loadLolMatchRequest: LoadLolMatchRequest): List<LoadLolMatchResponse> {
+    fun loadLolMatchesByUuid(@RequestBody loadLolMatchRequest: LoadLolMatchRequest): LoadLolMatchesByUuidResponse {
         return this.lolMatchService.loadLolMatchesByUuid(loadLolMatchRequest.toCommand())
     }
 }

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/presentation/LolMatchController.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/presentation/LolMatchController.kt
@@ -1,0 +1,22 @@
+package com.lol.analyzer.aram.lolmatch.presentation
+
+import com.lol.analyzer.aram.lolmatch.application.LolMatchService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/lol/matches")
+@Tag(name = "LolMatch", description = "LolMatch API")
+class LolMatchController(
+    private val lolMatchService: LolMatchService
+) {
+    @GetMapping("by-puuid/{puuid}")
+    @Operation(description = "PUUID 로 Match IDs 조회 (임시)")
+    fun loadLolMatchIdsByPuuid(@PathVariable("puuid") puuid: String): List<String> {
+        return this.lolMatchService.loadLolMatchesByPuuid(puuid)
+    }
+}

--- a/src/main/kotlin/com/lol/analyzer/aram/lolmatch/presentation/LolMatchController.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/lolmatch/presentation/LolMatchController.kt
@@ -1,10 +1,12 @@
 package com.lol.analyzer.aram.lolmatch.presentation
 
 import com.lol.analyzer.aram.lolmatch.application.LolMatchService
+import com.lol.analyzer.aram.lolmatch.domain.LolMatch
+import com.lol.analyzer.aram.lolmatch.dto.request.LoadLolMatchRequest
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -14,9 +16,9 @@ import org.springframework.web.bind.annotation.RestController
 class LolMatchController(
     private val lolMatchService: LolMatchService
 ) {
-    @GetMapping("by-puuid/{puuid}")
-    @Operation(description = "PUUID 로 Match IDs 조회 (임시)")
-    fun loadLolMatchIdsByPuuid(@PathVariable("puuid") puuid: String): List<String> {
-        return this.lolMatchService.loadLolMatchesByPuuid(puuid)
+    @PostMapping("/by-puuid")
+    @Operation(description = "PUUID 로 LoL Match 불러오기")
+    fun loadLolMatchesByPuuid(@RequestBody loadLolMatchRequest: LoadLolMatchRequest): List<LolMatch> {
+        return this.lolMatchService.loadLolMatchesByPuuid(loadLolMatchRequest.toCommand())
     }
 }

--- a/src/main/kotlin/com/lol/analyzer/aram/riot/domain/LolApi.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/riot/domain/LolApi.kt
@@ -7,4 +7,7 @@ import org.springframework.web.service.annotation.GetExchange
 interface LolApi {
     @GetExchange("/riot/account/v1/accounts/by-riot-id/{gameName}/{tagLine}")
     fun getAccountByRiotId(@PathVariable gameName: String, @PathVariable tagLine: String): RiotAccountResponse
+
+    @GetExchange("/lol/match/v5/matches/by-puuid/{puuid}/ids")
+    fun getLolMatchesByPuuid(@PathVariable puuid: String): List<String>
 }

--- a/src/main/kotlin/com/lol/analyzer/aram/riot/domain/LolApi.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/riot/domain/LolApi.kt
@@ -1,7 +1,7 @@
 package com.lol.analyzer.aram.riot.domain
 
-import com.lol.analyzer.aram.riot.dto.RiotAccountResponse
-import com.lol.analyzer.aram.riot.dto.RiotLolMatchResponse
+import com.lol.analyzer.aram.riot.dto.response.account.RiotAccountResponse
+import com.lol.analyzer.aram.riot.dto.response.lolmatch.RiotLolMatchResponse
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.service.annotation.GetExchange

--- a/src/main/kotlin/com/lol/analyzer/aram/riot/domain/LolApi.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/riot/domain/LolApi.kt
@@ -1,7 +1,9 @@
 package com.lol.analyzer.aram.riot.domain
 
 import com.lol.analyzer.aram.riot.dto.RiotAccountResponse
+import com.lol.analyzer.aram.riot.dto.RiotLolMatchResponse
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.service.annotation.GetExchange
 
 interface LolApi {
@@ -9,5 +11,12 @@ interface LolApi {
     fun getAccountByRiotId(@PathVariable gameName: String, @PathVariable tagLine: String): RiotAccountResponse
 
     @GetExchange("/lol/match/v5/matches/by-puuid/{puuid}/ids")
-    fun getLolMatchesByPuuid(@PathVariable puuid: String): List<String>
+    fun getLolMatchesByPuuid(
+        @PathVariable puuid: String,
+        @RequestParam start: Int? = null,
+        @RequestParam count: Int? = null,
+    ): List<String>
+
+    @GetExchange("/lol/match/v5/matches/{matchId}")
+    fun getLolMatchByMatchId(@PathVariable matchId: String): RiotLolMatchResponse
 }

--- a/src/main/kotlin/com/lol/analyzer/aram/riot/domain/TftApi.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/riot/domain/TftApi.kt
@@ -1,8 +1,4 @@
 package com.lol.analyzer.aram.riot.domain
 
-import com.lol.analyzer.aram.riot.dto.RiotAccountResponse
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.service.annotation.GetExchange
-
 interface TftApi {
 }

--- a/src/main/kotlin/com/lol/analyzer/aram/riot/dto/RiotLolMatchResponse.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/riot/dto/RiotLolMatchResponse.kt
@@ -1,0 +1,6 @@
+package com.lol.analyzer.aram.riot.dto
+
+data class RiotLolMatchResponse(
+    val gameDuration: Long
+) {
+}

--- a/src/main/kotlin/com/lol/analyzer/aram/riot/dto/RiotLolMatchResponse.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/riot/dto/RiotLolMatchResponse.kt
@@ -1,6 +1,0 @@
-package com.lol.analyzer.aram.riot.dto
-
-data class RiotLolMatchResponse(
-    val gameDuration: Long
-) {
-}

--- a/src/main/kotlin/com/lol/analyzer/aram/riot/dto/response/account/RiotAccountResponse.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/riot/dto/response/account/RiotAccountResponse.kt
@@ -1,4 +1,4 @@
-package com.lol.analyzer.aram.riot.dto
+package com.lol.analyzer.aram.riot.dto.response.account
 
 data class RiotAccountResponse(
     val puuid: String,

--- a/src/main/kotlin/com/lol/analyzer/aram/riot/dto/response/lolmatch/RiotLolMatchInfoResponse.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/riot/dto/response/lolmatch/RiotLolMatchInfoResponse.kt
@@ -2,13 +2,14 @@ package com.lol.analyzer.aram.riot.dto.response.lolmatch
 
 import com.lol.analyzer.aram.common.enums._enums.GameMode
 import com.lol.analyzer.aram.common.enums._enums.GameType
+import com.lol.analyzer.aram.common.enums._enums.Maps
 
 data class RiotLolMatchInfoResponse(
     val gameStartTimestamp: Long,
     val gameEndTimestamp: Long,
     val gameMode: GameMode,
     val gameType: GameType,
-    val mapId: Int,
+    val mapId: Maps,
     val participants: List<RiotLolMatchParticipantResponse> = listOf()
 ) {
 }

--- a/src/main/kotlin/com/lol/analyzer/aram/riot/dto/response/lolmatch/RiotLolMatchInfoResponse.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/riot/dto/response/lolmatch/RiotLolMatchInfoResponse.kt
@@ -1,0 +1,14 @@
+package com.lol.analyzer.aram.riot.dto.response.lolmatch
+
+import com.lol.analyzer.aram.common.enums._enums.GameMode
+import com.lol.analyzer.aram.common.enums._enums.GameType
+
+data class RiotLolMatchInfoResponse(
+    val gameStartTimestamp: Long,
+    val gameEndTimestamp: Long,
+    val gameMode: GameMode,
+    val gameType: GameType,
+    val mapId: Int,
+    val participants: List<RiotLolMatchParticipantResponse> = listOf()
+) {
+}

--- a/src/main/kotlin/com/lol/analyzer/aram/riot/dto/response/lolmatch/RiotLolMatchMetadataResponse.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/riot/dto/response/lolmatch/RiotLolMatchMetadataResponse.kt
@@ -1,0 +1,8 @@
+package com.lol.analyzer.aram.riot.dto.response.lolmatch
+
+data class RiotLolMatchMetadataResponse(
+    val dataVersion: String,
+    val matchId: String,
+    val participants: List<String> = listOf()
+) {
+}

--- a/src/main/kotlin/com/lol/analyzer/aram/riot/dto/response/lolmatch/RiotLolMatchParticipantResponse.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/riot/dto/response/lolmatch/RiotLolMatchParticipantResponse.kt
@@ -1,0 +1,24 @@
+package com.lol.analyzer.aram.riot.dto.response.lolmatch
+
+data class RiotLolMatchParticipantResponse(
+    val puuid: String,
+    val lane: String,
+    val physicalDamageDealt: Int,
+    val physicalDamageDealtToChampions: Int,
+    val physicalDamageTaken: Int,
+    val magicDamageDealt: Int,
+    val magicDamageDealtToChampions: Int,
+    val magicDamageTaken: Int,
+    val championName: String,
+    val kills: Int,
+    val deaths: Int,
+    val assists: Int,
+    val win: Boolean,
+    val item0: Int,
+    val item1: Int,
+    val item2: Int,
+    val item3: Int,
+    val item4: Int,
+    val item5: Int
+) {
+}

--- a/src/main/kotlin/com/lol/analyzer/aram/riot/dto/response/lolmatch/RiotLolMatchResponse.kt
+++ b/src/main/kotlin/com/lol/analyzer/aram/riot/dto/response/lolmatch/RiotLolMatchResponse.kt
@@ -1,0 +1,7 @@
+package com.lol.analyzer.aram.riot.dto.response.lolmatch
+
+data class RiotLolMatchResponse(
+    val metadata: RiotLolMatchMetadataResponse,
+    val info: RiotLolMatchInfoResponse
+) {
+}


### PR DESCRIPTION
## 관련 이슈
- issue link

## 작업 내용
- LolMatch & AccountLolMatch Entity 생성
>- Riot API 의 Response DTO 를 참고하여 테이블 생성
>- 여러 Enum 값들의 Converter 작성 (DB 컬럼 <-> entity attribute)
- QueryDSL 적용
>- account 정보를 통해 lol match 들을 불러오는 것은 기본적인 JpaRepository 로는 구현이 어렵다고 판단
>- Custom Repository 를 구현하기 위해 QueryDSL 적용
>- LolMatchCustomRepository 인터페이스의 구현체 LolMatchCustomRepositoryImpl 에 적용
>- N + 1 query 를 막기 위해 fetchJoin 사용, 학습이 더 필요
- POST loadLolMatchesByUuid API 작성
>- pagination 구현 방식으로 cursor 패턴을 채택
>- 관련 Request / Response DTO 작성
>- count 만큼 불러온 뒤 DB 에 쿼리를 날린 결과가 count 보다 적다면 Riot API 를 통해 count 2배만큼 더 불러온뒤 result 를 반환
>- Riot API 를 통해 가져온 데이터를 LolMatch && AccountLolMatch 로 save 할 때 코루틴을 적용할 수 있을지?

## Checklist
- [ ] 